### PR TITLE
fix: enum for `shell` key

### DIFF
--- a/schemas/Espanso_Match_Schema.json
+++ b/schemas/Espanso_Match_Schema.json
@@ -190,7 +190,7 @@
                 "description": "Specifically for the shell extension, this option specifies what shell the commands specified using the cmd property will run in",
                 "type": "string",
                 "enum": [
-                  "\"cmd\",\"powershell\",\"wsl\",\"sh\",\"bash\""
+                  "cmd", "powershell", "wsl", "sh", "bash"
                 ]
               },
               "format": {


### PR DESCRIPTION
Thanks again for this schema!

<img width="1226" alt="Pasted image 2023-10-13 at 11 11 49@2x" src="https://github.com/ajmarkow/espanso-schema-json/assets/73286100/a174d25c-5b91-442b-a5d5-2eb4111b0286">
